### PR TITLE
Simplify use of custom context in diff engine

### DIFF
--- a/src/main/java/org/diffkit/diff/engine/DKDiffEngine.java
+++ b/src/main/java/org/diffkit/diff/engine/DKDiffEngine.java
@@ -56,7 +56,7 @@ public class DKDiffEngine {
       return context;
    }
 
-   private void diff(DKContext context_) throws IOException {
+   protected void diff(DKContext context_) throws IOException {
       long maxDiffs = context_._tableComparison.getMaxDiffs();
       _log.info("maxDiffs->{}", maxDiffs);
       context_.open();


### PR DESCRIPTION
I am currently working on a small application which uses DiffKit as library. I've had to extend a few classes but hit a little bit of a roadblock when using a custom context.

There appears to be no easy way to include a little bit of extra information in the context without copying all methods in `DKDiffEngine`. This pull request simply changes the `DKDiffEngine.diff(Context)` method from private to protected.

This isn't a perfect solution, but it removes one roadblock when extending the functionality of DiffKit.