### PR TITLE
Package executable jar (with dependencies)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,7 @@ jdk:
 
 before_install:
   - pip install --user codecov
+  - export MAVEN_SKIP_RC='true'
+  - export MAVEN_OPTS='-Xmx1024m'
 after_success:
   - codecov

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.5.5</version>
+                <configuration>
+                    <finalName>diffkit-app</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <attach>false</attach>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.diffkit.diff.conf.DKLauncher</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>app-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Adds a plugin to the project for creating an executable JAR-file (containing all dependencies). This is similar to what was included with the [DiffKit downloads](https://code.google.com/archive/p/diffkit/downloads).

The file can be built using `mvn package`. It is not installed when running `mvn install`, but is build regardless.