### PR TITLE
Less verbose info-level log

### DIFF
--- a/src/main/java/org/diffkit/diff/conf/DKDemoDB.java
+++ b/src/main/java/org/diffkit/diff/conf/DKDemoDB.java
@@ -62,11 +62,11 @@ public class DKDemoDB {
          throw new RuntimeException(String.format(
             "cannot find connectionInfo in Spring config file->%s",
             CONNECTION_INFO_CONFIG_FILE_PATH));
-      LOG.info("connectionInfo->{}", connectionInfo);
+      LOG.debug("connectionInfo->{}", connectionInfo);
       DKDatabase connectionSource = new DKDatabase(connectionInfo);
       DKDBTableDataAccess tableDataAccess = new DKDBTableDataAccess(connectionSource);
       DKDBTable table = tableDataAccess.getTable(PROBE_TABLE_NAME);
-      LOG.info("table->{}", table);
+      LOG.debug("table->{}", table);
       return (table != null);
    }
 }

--- a/src/main/java/org/diffkit/diff/conf/DKTestBridge.java
+++ b/src/main/java/org/diffkit/diff/conf/DKTestBridge.java
@@ -37,8 +37,8 @@ public class DKTestBridge {
    private static final Logger LOG = LoggerFactory.getLogger(DKTestBridge.class);
 
    public static void runTestCases(String casesString_, List<DKDBFlavor> flavors_) {
-      LOG.info("cases_->{}", casesString_);
-      LOG.info("flavors_->{}", flavors_);
+      LOG.debug("cases_->{}", casesString_);
+      LOG.debug("flavors_->{}", flavors_);
       DKRuntime.getInstance().setIsTest(Boolean.TRUE);
       try {
          Runnable testCaseRunner = (Runnable) getTestCaseRunner(casesString_, flavors_);
@@ -58,7 +58,7 @@ public class DKTestBridge {
    private static Object getTestCaseRunner(String casesString_, List<DKDBFlavor> flavors_)
       throws Exception {
       Class<?> testCaseRunnerClass = Class.forName(TESTCASERUNNER_CLASS_NAME);
-      LOG.info("testCaseRunnerClass->{}", testCaseRunnerClass);
+      LOG.debug("testCaseRunnerClass->{}", testCaseRunnerClass);
       Constructor<?> constructor = DKClassUtil.findLongestConstructor(testCaseRunnerClass);
       LOG.debug("constructor->{}", constructor);
       return constructor.newInstance(casesString_, flavors_);

--- a/src/main/java/org/diffkit/diff/engine/DKDiffEngine.java
+++ b/src/main/java/org/diffkit/diff/engine/DKDiffEngine.java
@@ -42,28 +42,28 @@ public class DKDiffEngine {
    public DKContext diff(DKSource lhs_, DKSource rhs_, DKSink sink_,
                          DKTableComparison tableComparison_,
                          Map<UserKey, ?> userDictionary_) throws IOException {
-      _log.info("lhs_->{}", lhs_);
-      _log.info("rhs_->{}", rhs_);
-      _log.info("sink_->{}", sink_);
-      _log.info("tableComparison_->{}", tableComparison_.getDescription());
+      _log.debug("lhs_->{}", lhs_);
+      _log.debug("rhs_->{}", rhs_);
+      _log.debug("sink_->{}", sink_);
+      _log.debug("tableComparison_->{}", tableComparison_.getDescription());
       _log.debug("userDictionary_->{}", userDictionary_);
 
       DKValidate.notNull(lhs_, rhs_, sink_, tableComparison_);
       DKContext context = new DKContext(lhs_, rhs_, sink_, tableComparison_,
          userDictionary_);
-      _log.info("context->{}", context);
+      _log.debug("context->{}", context);
       this.diff(context);
       return context;
    }
 
    protected void diff(DKContext context_) throws IOException {
       long maxDiffs = context_._tableComparison.getMaxDiffs();
-      _log.info("maxDiffs->{}", maxDiffs);
+      _log.debug("maxDiffs->{}", maxDiffs);
       context_.open();
       int oneSide = -1;
       Object[][] rows = new Object[2][];
       Comparator<Object[]> rowComparator = context_._tableComparison.getRowComparator();
-      _log.info("rowComparator->{}", rowComparator);
+      _log.debug("rowComparator->{}", rowComparator);
       while (context_._sink.getDiffCount() < maxDiffs) {
          if (_isDebug)
             _log.debug("diffCount->{}", context_._sink.getDiffCount());

--- a/src/main/java/org/diffkit/diff/sns/DKDBSink.java
+++ b/src/main/java/org/diffkit/diff/sns/DKDBSink.java
@@ -76,7 +76,7 @@ public class DKDBSink extends DKAbstractSink {
          _log.error(null, e_);
          throw new RuntimeException(e_);
       }
-      _log.info("_connection->{}", _connection);
+      _log.debug("_connection->{}", _connection);
    }
 
    public void close(DKContext context_) throws IOException {

--- a/src/main/java/org/diffkit/diff/sns/DKDBSource.java
+++ b/src/main/java/org/diffkit/diff/sns/DKDBSource.java
@@ -79,12 +79,12 @@ public class DKDBSource implements DKSource {
    public DKDBSource(String tableName_, String whereClause_, DKDatabase database_,
                      DKTableModel model_, String[] keyColumnNames_, int[] readColumnIdxs_)
       throws SQLException {
-      _log.info("tableName_->{}", tableName_);
-      _log.info("whereClause_->{}", whereClause_);
-      _log.info("database_->{}", database_);
-      _log.info("model_->{}", model_);
-      _log.info("keyColumnNames_->{}", keyColumnNames_);
-      _log.info("readColumnIdxs_->{}", readColumnIdxs_);
+      _log.debug("tableName_->{}", tableName_);
+      _log.debug("whereClause_->{}", whereClause_);
+      _log.debug("database_->{}", database_);
+      _log.debug("model_->{}", model_);
+      _log.debug("keyColumnNames_->{}", keyColumnNames_);
+      _log.debug("readColumnIdxs_->{}", readColumnIdxs_);
 
       if (readColumnIdxs_ != null)
          throw new NotImplementedException("readColumnIdxs_ not yet implemented");
@@ -96,7 +96,7 @@ public class DKDBSource implements DKSource {
       _database = database_;
       DKValidate.notNull(_database);
       _table = _database.getTable(tableName_);
-      _log.info("table->{}", _table);
+      _log.debug("table->{}", _table);
       DKValidate.notNull(_tableName);
       if (_table == null)
          throw new RuntimeException(String.format("couldn't find table named->%s",
@@ -104,7 +104,7 @@ public class DKDBSource implements DKSource {
       this.validateKeyColumnNames(_table, keyColumnNames_);
       _keyColumnNames = keyColumnNames_;
       _model = this.getModel(model_, _keyColumnNames, _table);
-      _log.info("_model->{}", _model);
+      _log.debug("_model->{}", _model);
       DKValidate.notNull(_model);
       this.validateModel(_model, _table);
    }

--- a/src/main/java/org/diffkit/diff/sns/DKFileSource.java
+++ b/src/main/java/org/diffkit/diff/sns/DKFileSource.java
@@ -292,7 +292,7 @@ public class DKFileSource implements DKSource {
 
    private void readHeader() throws IOException {
       String line = this.readLine();
-      _log.info("header->{}", line);
+      _log.debug("header->{}", line);
       _headerColumnNames = line.split(_delimiter);
    }
 

--- a/src/main/java/org/diffkit/diff/sns/DKPoiSheet.java
+++ b/src/main/java/org/diffkit/diff/sns/DKPoiSheet.java
@@ -170,7 +170,7 @@ public class DKPoiSheet extends DKAbstractSheet {
          throw new IOException(String.format("no sheet!"));
       Iterator<Row> rowIterator = sheet.rowIterator();
       _rows = IteratorUtils.toList(rowIterator);
-      _log.info("row count->{}", (_rows == null) ? 0 : _rows.size());
+      _log.debug("row count->{}", (_rows == null) ? 0 : _rows.size());
       return _rows;
    }
 

--- a/src/main/java/org/diffkit/diff/sns/DKWriterSink.java
+++ b/src/main/java/org/diffkit/diff/sns/DKWriterSink.java
@@ -82,7 +82,7 @@ public class DKWriterSink extends DKAbstractSink {
 
    public void open(DKContext context_) throws IOException {
       super.open(context_);
-      _log.info("_writer->{}", _writer);
+      _log.debug("_writer->{}", _writer);
    }
 
    public void close(DKContext context_) throws IOException {

--- a/src/test/java/org/diffkit/diff/conf/tst/LaunchMe.java
+++ b/src/test/java/org/diffkit/diff/conf/tst/LaunchMe.java
@@ -28,7 +28,7 @@ public class LaunchMe {
    private static final Logger LOG = LoggerFactory.getLogger(LaunchMe.class);
 
    public static void main(String[] args_) {
-      LOG.info("args_->{}", Arrays.toString(args_));
+      LOG.debug("args_->{}", Arrays.toString(args_));
    }
 
 }

--- a/src/test/java/org/diffkit/diff/testcase/TestCaseRunner.groovy
+++ b/src/test/java/org/diffkit/diff/testcase/TestCaseRunner.groovy
@@ -111,7 +111,7 @@ public class TestCaseRunner implements Runnable {
    }
    
    public TestCaseRunnerRun run(DKDBFlavor flavor_){
-      _log.info("flavor_->{}",flavor_)
+      _log.debug("flavor_->{}",flavor_)
       def runnerRun = this.setupRunnerRun(flavor_)
       if(!runnerRun) {
          _log.info("can't setup runnerRun; exiting.")
@@ -135,7 +135,7 @@ public class TestCaseRunner implements Runnable {
       }
       
       Collections.sort(testCases)
-      _log.info("testCases->{}",testCases)
+      _log.debug("testCases->{}",testCases)
       testCases.each {
          this.setupAndExecute(it, runnerRun)
       }
@@ -153,18 +153,18 @@ public class TestCaseRunner implements Runnable {
       }
       TestCaseRunnerRun runnerRun = [new File('./tstscratch/'), flavor_]
       def classLoader = this.class.classLoader
-      _log.info("classLoader->{}",classLoader)
+      _log.debug("classLoader->{}",classLoader)
       URL dataPathUrl = classLoader.getResource(_dataPath)
-      _log.info("dataPathUrl->{}",dataPathUrl)
+      _log.debug("dataPathUrl->{}",dataPathUrl)
       def substitutionMap = [:]
       substitutionMap.put(TARGET_DATABASE_TOKEN, DEFAULT_TESTCASE_DATABASE)
       substitutionMap.put(TEST18_LHS_TARGET_DATABASE_TOKEN, TEST18_LHS_TARGET_DATABASE)
       substitutionMap.put(TEST18_RHS_TARGET_DATABASE_TOKEN, TEST18_RHS_TARGET_DATABASE)
       if(dataPathUrl.toExternalForm().startsWith("jar:")){
          String testDataArchiveResourcePath = _dataPath + TEST_CASE_DATA_ARCHIVE_NAME
-         _log.info("testDataArchiveResourcePath->{}",testDataArchiveResourcePath)
+         _log.debug("testDataArchiveResourcePath->{}",testDataArchiveResourcePath)
          InputStream archiveInputStream = classLoader.getResourceAsStream(testDataArchiveResourcePath)
-         _log.info("archiveInputStream->{}",archiveInputStream)
+         _log.debug("archiveInputStream->{}",archiveInputStream)
          if(!archiveInputStream) {
             _log.error("couldn't find archive at path->{}",testDataArchiveResourcePath)
             return null
@@ -287,7 +287,7 @@ public class TestCaseRunner implements Runnable {
    }
    
    private void setupAndExecute(TestCase testCase_, TestCaseRunnerRun runnerRun_){
-      _log.info("testCase_->{}",testCase_.description)
+      _log.debug("testCase_->{}",testCase_.description)
       DKPlan plan = null
       Exception exception = null
       try{


### PR DESCRIPTION
This changes the log level for variable values from `INFO` to `DEBUG`.

This may be more of a personal opinion, but I feel that logging of variables values is a bit too verbose for the `INFO` level. It makes it a bit difficult for me to get an quick overview of what happens on a higher level when running multiple plans at the same time. Learning the values of variables is something I'd use a debugger for either way.

The [log4j](https://www.tutorialspoint.com/log4j/log4j_logging_levels.htm) documentation defines the two levels as follows:

- DEBUG, Designates fine-grained informational events that are most useful to debug an application.
- INFO, Designates informational messages that highlight the progress of the application at coarse-grained level.

This pull request does not change anything related to the user log or system log, so output on the command line *should* stay the same.